### PR TITLE
fix for android tv and stremio web

### DIFF
--- a/lib/addon_helper.js
+++ b/lib/addon_helper.js
@@ -24,6 +24,7 @@ function formatCatalog(catalog) {
     description: catalog.description.replace(/([</p>\n])/g, "").trim(),
     posterShape: "poster",
     type: "movie",
+    behaviorHints: { defaultVideoId: catalog.slug }
   };
 }
 


### PR DESCRIPTION
having catalogElement.behaviorHints.defaultVideoId equal to catalogElement.id is the only way to get streams to show properly on android tv and stremio web